### PR TITLE
add toDictionary, toJSONString

### DIFF
--- a/Sources/RxCodable/Maybe+RxCodable.swift
+++ b/Sources/RxCodable/Maybe+RxCodable.swift
@@ -18,3 +18,11 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait, ElementTyp
   }
 }
 
+public extension PrimitiveSequenceType where TraitType == MaybeTrait, ElementType == [String: Any] {
+  public func map<T>(_ type: T.Type, using decoder: JSONDecoder? = nil) -> PrimitiveSequence<TraitType, T> where T: Decodable {
+    return self
+      .map { dict in try JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted) }
+      .map(type, using: decoder)
+  }
+}
+

--- a/Sources/RxCodable/Maybe+RxCodable.swift
+++ b/Sources/RxCodable/Maybe+RxCodable.swift
@@ -27,19 +27,20 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait, ElementTyp
 }
 
 public extension PrimitiveSequenceType where TraitType == MaybeTrait, ElementType: Encodable {
-  public func toDictionary() -> PrimitiveSequence<TraitType, [String:Any]> {
+  public func toDictionary(_ encoder: JSONEncoder? = nil) -> PrimitiveSequence<TraitType, [String: Any]> {
     return self.map { encodable -> [String: Any] in
-      let data = try JSONEncoder().encode(encodable)
-      let dictionary = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-      return dictionary ?? [:]
+      let data = try (encoder ?? JSONEncoder()).encode(encodable)
+      let dict = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+      guard let dictionary = dict else { throw RxError.noElements }
+      return dictionary
     }
   }
 }
 
 public extension PrimitiveSequenceType where TraitType == MaybeTrait, ElementType: Encodable {
-  public func toJSONString(_ encoding: String.Encoding = .utf8) -> PrimitiveSequence<TraitType, String> {
+  public func toJSONString(_ encoding: String.Encoding = .utf8, using encoder: JSONEncoder? = nil) -> PrimitiveSequence<TraitType, String> {
     return self.map { encodable -> String in
-      let data = try JSONEncoder().encode(encodable)
+      let data = try (encoder ?? JSONEncoder()).encode(encodable)
       let json = String(data: data, encoding: encoding)
       return json ?? "{}"
     }

--- a/Sources/RxCodable/Maybe+RxCodable.swift
+++ b/Sources/RxCodable/Maybe+RxCodable.swift
@@ -38,7 +38,7 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait, ElementTyp
 }
 
 public extension PrimitiveSequenceType where TraitType == MaybeTrait, ElementType: Encodable {
-  public func toJSONString(_ encoding: String.Encoding = .utf8, using encoder: JSONEncoder? = nil) -> PrimitiveSequence<TraitType, String> {
+  public func toJSONString(_ encoder: JSONEncoder? = nil, encoding: String.Encoding = .utf8) -> PrimitiveSequence<TraitType, String> {
     return self.map { encodable -> String in
       let data = try (encoder ?? JSONEncoder()).encode(encodable)
       let json = String(data: data, encoding: encoding)

--- a/Sources/RxCodable/Maybe+RxCodable.swift
+++ b/Sources/RxCodable/Maybe+RxCodable.swift
@@ -21,8 +21,27 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait, ElementTyp
 public extension PrimitiveSequenceType where TraitType == MaybeTrait, ElementType == [String: Any] {
   public func map<T>(_ type: T.Type, using decoder: JSONDecoder? = nil) -> PrimitiveSequence<TraitType, T> where T: Decodable {
     return self
-      .map { dict in try JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted) }
+      .map { dict in try JSONSerialization.data(withJSONObject: dict) }
       .map(type, using: decoder)
   }
 }
 
+public extension PrimitiveSequenceType where TraitType == MaybeTrait, ElementType: Encodable {
+  public func toDictionary() -> PrimitiveSequence<TraitType, [String:Any]> {
+    return self.map { encodable -> [String: Any] in
+      let data = try JSONEncoder().encode(encodable)
+      let dictionary = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+      return dictionary ?? [:]
+    }
+  }
+}
+
+public extension PrimitiveSequenceType where TraitType == MaybeTrait, ElementType: Encodable {
+  public func toJSONString(_ encoding: String.Encoding = .utf8) -> PrimitiveSequence<TraitType, String> {
+    return self.map { encodable -> String in
+      let data = try JSONEncoder().encode(encodable)
+      let json = String(data: data, encoding: encoding)
+      return json ?? "{}"
+    }
+  }
+}

--- a/Sources/RxCodable/Maybe+RxCodable.swift
+++ b/Sources/RxCodable/Maybe+RxCodable.swift
@@ -26,23 +26,40 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait, ElementTyp
   }
 }
 
+public extension PrimitiveSequenceType where TraitType == MaybeTrait, ElementType == [[String: Any]] {
+  public func map<T>(_ type: Array<T>.Type, using decoder: JSONDecoder? = nil) -> PrimitiveSequence<TraitType, [T]> where T: Decodable {
+    return self
+      .flatMap {
+        Observable.from($0)
+          .map(T.self, using: decoder)
+          .toArray()
+          .asMaybe()
+      }
+  }
+}
+
 public extension PrimitiveSequenceType where TraitType == MaybeTrait, ElementType: Encodable {
-  public func toDictionary(_ encoder: JSONEncoder? = nil) -> PrimitiveSequence<TraitType, [String: Any]> {
+  public func mapDictionary(_ encoder: JSONEncoder? = nil) -> PrimitiveSequence<TraitType, [String: Any]> {
     return self.map { encodable -> [String: Any] in
       let data = try (encoder ?? JSONEncoder()).encode(encodable)
       let dict = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-      guard let dictionary = dict else { throw RxError.noElements }
+      guard let dictionary = dict else {
+        throw RxCodableError.castingFailed(data: data, type: [String: Any].self)
+      }
       return dictionary
     }
   }
 }
 
 public extension PrimitiveSequenceType where TraitType == MaybeTrait, ElementType: Encodable {
-  public func toJSONString(_ encoder: JSONEncoder? = nil, encoding: String.Encoding = .utf8) -> PrimitiveSequence<TraitType, String> {
+  public func mapJSONString(_ encoder: JSONEncoder? = nil, encoding: String.Encoding = .utf8) -> PrimitiveSequence<TraitType, String> {
     return self.map { encodable -> String in
       let data = try (encoder ?? JSONEncoder()).encode(encodable)
       let json = String(data: data, encoding: encoding)
-      return json ?? "{}"
+      guard let jsonString = json else {
+        throw RxCodableError.castingFailed(data: data, type: String.self)
+      }
+      return jsonString
     }
   }
 }

--- a/Sources/RxCodable/ObservableType+RxCodable.swift
+++ b/Sources/RxCodable/ObservableType+RxCodable.swift
@@ -38,7 +38,7 @@ public extension ObservableType where E: Encodable {
 }
 
 public extension ObservableType where E: Encodable {
-  public func toJSONString(_ encoding: String.Encoding = .utf8, using encoder: JSONEncoder? = nil) -> Observable<String> {
+  public func toJSONString(_ encoder: JSONEncoder? = nil, encoding: String.Encoding = .utf8) -> Observable<String> {
     return self.map { encodable -> String in
       let data = try (encoder ?? JSONEncoder()).encode(encodable)
       let json = String(data: data, encoding: encoding)

--- a/Sources/RxCodable/ObservableType+RxCodable.swift
+++ b/Sources/RxCodable/ObservableType+RxCodable.swift
@@ -27,21 +27,23 @@ public extension ObservableType where E == [String: Any] {
 }
 
 public extension ObservableType where E: Encodable {
-  public func toDictionary() -> Observable<[String:Any]> {
+  public func toDictionary(_ encoder: JSONEncoder? = nil) -> Observable<[String: Any]> {
     return self.map { encodable -> [String: Any] in
-      let data = try JSONEncoder().encode(encodable)
-      let dictionary = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-      return dictionary ?? [:]
+      let data = try (encoder ?? JSONEncoder()).encode(encodable)
+      let dict = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+      guard let dictionary = dict else { throw RxError.noElements }
+      return dictionary
     }
   }
 }
 
 public extension ObservableType where E: Encodable {
-  public func toJSONString(_ encoding: String.Encoding = .utf8) -> Observable<String> {
+  public func toJSONString(_ encoding: String.Encoding = .utf8, using encoder: JSONEncoder? = nil) -> Observable<String> {
     return self.map { encodable -> String in
-      let data = try JSONEncoder().encode(encodable)
+      let data = try (encoder ?? JSONEncoder()).encode(encodable)
       let json = String(data: data, encoding: encoding)
       return json ?? "{}"
     }
   }
 }
+

--- a/Sources/RxCodable/ObservableType+RxCodable.swift
+++ b/Sources/RxCodable/ObservableType+RxCodable.swift
@@ -26,23 +26,37 @@ public extension ObservableType where E == [String: Any] {
   }
 }
 
+public extension ObservableType where E == [[String: Any]] {
+  public func map<T>(_ type: Array<T>.Type, using decoder: JSONDecoder? = nil) -> Observable<[T]> where T: Decodable {
+    return self
+      .flatMap { Observable.from($0) }
+      .map(T.self, using: decoder)
+      .toArray()
+  }
+}
+
 public extension ObservableType where E: Encodable {
-  public func toDictionary(_ encoder: JSONEncoder? = nil) -> Observable<[String: Any]> {
+  public func mapDictionary(_ encoder: JSONEncoder? = nil) -> Observable<[String: Any]> {
     return self.map { encodable -> [String: Any] in
       let data = try (encoder ?? JSONEncoder()).encode(encodable)
       let dict = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-      guard let dictionary = dict else { throw RxError.noElements }
+      guard let dictionary = dict else {
+        throw RxCodableError.castingFailed(data: data, type: [String: Any].self)
+      }
       return dictionary
     }
   }
 }
 
 public extension ObservableType where E: Encodable {
-  public func toJSONString(_ encoder: JSONEncoder? = nil, encoding: String.Encoding = .utf8) -> Observable<String> {
+  public func mapJSONString(_ encoder: JSONEncoder? = nil, encoding: String.Encoding = .utf8) -> Observable<String> {
     return self.map { encodable -> String in
       let data = try (encoder ?? JSONEncoder()).encode(encodable)
       let json = String(data: data, encoding: encoding)
-      return json ?? "{}"
+      guard let jsonString = json else {
+        throw RxCodableError.castingFailed(data: data, type: String.self)
+      }
+      return jsonString
     }
   }
 }

--- a/Sources/RxCodable/ObservableType+RxCodable.swift
+++ b/Sources/RxCodable/ObservableType+RxCodable.swift
@@ -21,7 +21,27 @@ public extension ObservableType where E == String {
 public extension ObservableType where E == [String: Any] {
   public func map<T>(_ type: T.Type, using decoder: JSONDecoder? = nil) -> Observable<T> where T: Decodable {
     return self
-      .map { dict in try JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted) }
+      .map { dict in try JSONSerialization.data(withJSONObject: dict) }
       .map(type, using: decoder)
+  }
+}
+
+public extension ObservableType where E: Encodable {
+  public func toDictionary() -> Observable<[String:Any]> {
+    return self.map { encodable -> [String: Any] in
+      let data = try JSONEncoder().encode(encodable)
+      let dictionary = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+      return dictionary ?? [:]
+    }
+  }
+}
+
+public extension ObservableType where E: Encodable {
+  public func toJSONString(_ encoding: String.Encoding = .utf8) -> Observable<String> {
+    return self.map { encodable -> String in
+      let data = try JSONEncoder().encode(encodable)
+      let json = String(data: data, encoding: encoding)
+      return json ?? "{}"
+    }
   }
 }

--- a/Sources/RxCodable/ObservableType+RxCodable.swift
+++ b/Sources/RxCodable/ObservableType+RxCodable.swift
@@ -17,3 +17,11 @@ public extension ObservableType where E == String {
       .map(type, using: decoder)
   }
 }
+
+public extension ObservableType where E == [String: Any] {
+  public func map<T>(_ type: T.Type, using decoder: JSONDecoder? = nil) -> Observable<T> where T: Decodable {
+    return self
+      .map { dict in try JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted) }
+      .map(type, using: decoder)
+  }
+}

--- a/Sources/RxCodable/RxCodableError.swift
+++ b/Sources/RxCodable/RxCodableError.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public enum RxCodableError: Error {
+  case castingFailed(data: Any, type: Any.Type)
+}

--- a/Sources/RxCodable/Single+RxCodable.swift
+++ b/Sources/RxCodable/Single+RxCodable.swift
@@ -38,7 +38,7 @@ public extension PrimitiveSequenceType where TraitType == SingleTrait, ElementTy
 }
 
 public extension PrimitiveSequenceType where TraitType == SingleTrait, ElementType: Encodable {
-  public func toJSONString(_ encoding: String.Encoding = .utf8, using encoder: JSONEncoder? = nil) -> PrimitiveSequence<TraitType, String> {
+  public func toJSONString(_ encoder: JSONEncoder? = nil, encoding: String.Encoding = .utf8) -> PrimitiveSequence<TraitType, String> {
     return self.map { encodable -> String in
       let data = try (encoder ?? JSONEncoder()).encode(encodable)
       let json = String(data: data, encoding: encoding)

--- a/Sources/RxCodable/Single+RxCodable.swift
+++ b/Sources/RxCodable/Single+RxCodable.swift
@@ -27,19 +27,20 @@ public extension PrimitiveSequenceType where TraitType == SingleTrait, ElementTy
 }
 
 public extension PrimitiveSequenceType where TraitType == SingleTrait, ElementType: Encodable {
-  public func toDictionary() -> PrimitiveSequence<TraitType, [String:Any]> {
+  public func toDictionary(_ encoder: JSONEncoder? = nil) -> PrimitiveSequence<TraitType, [String: Any]> {
     return self.map { encodable -> [String: Any] in
-      let data = try JSONEncoder().encode(encodable)
-      let dictionary = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-      return dictionary ?? [:]
+      let data = try (encoder ?? JSONEncoder()).encode(encodable)
+      let dict = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+      guard let dictionary = dict else { throw RxError.noElements }
+      return dictionary
     }
   }
 }
 
 public extension PrimitiveSequenceType where TraitType == SingleTrait, ElementType: Encodable {
-  public func toJSONString(_ encoding: String.Encoding = .utf8) -> PrimitiveSequence<TraitType, String> {
+  public func toJSONString(_ encoding: String.Encoding = .utf8, using encoder: JSONEncoder? = nil) -> PrimitiveSequence<TraitType, String> {
     return self.map { encodable -> String in
-      let data = try JSONEncoder().encode(encodable)
+      let data = try (encoder ?? JSONEncoder()).encode(encodable)
       let json = String(data: data, encoding: encoding)
       return json ?? "{}"
     }

--- a/Sources/RxCodable/Single+RxCodable.swift
+++ b/Sources/RxCodable/Single+RxCodable.swift
@@ -17,3 +17,11 @@ public extension PrimitiveSequenceType where TraitType == SingleTrait, ElementTy
       .map(type, using: decoder)
   }
 }
+
+public extension PrimitiveSequenceType where TraitType == SingleTrait, ElementType == [String: Any] {
+  public func map<T>(_ type: T.Type, using decoder: JSONDecoder? = nil) -> PrimitiveSequence<TraitType, T> where T: Decodable {
+    return self
+      .map { dict in try JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted) }
+      .map(type, using: decoder)
+  }
+}

--- a/Sources/RxCodable/Single+RxCodable.swift
+++ b/Sources/RxCodable/Single+RxCodable.swift
@@ -21,7 +21,27 @@ public extension PrimitiveSequenceType where TraitType == SingleTrait, ElementTy
 public extension PrimitiveSequenceType where TraitType == SingleTrait, ElementType == [String: Any] {
   public func map<T>(_ type: T.Type, using decoder: JSONDecoder? = nil) -> PrimitiveSequence<TraitType, T> where T: Decodable {
     return self
-      .map { dict in try JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted) }
+      .map { dict in try JSONSerialization.data(withJSONObject: dict) }
       .map(type, using: decoder)
+  }
+}
+
+public extension PrimitiveSequenceType where TraitType == SingleTrait, ElementType: Encodable {
+  public func toDictionary() -> PrimitiveSequence<TraitType, [String:Any]> {
+    return self.map { encodable -> [String: Any] in
+      let data = try JSONEncoder().encode(encodable)
+      let dictionary = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+      return dictionary ?? [:]
+    }
+  }
+}
+
+public extension PrimitiveSequenceType where TraitType == SingleTrait, ElementType: Encodable {
+  public func toJSONString(_ encoding: String.Encoding = .utf8) -> PrimitiveSequence<TraitType, String> {
+    return self.map { encodable -> String in
+      let data = try JSONEncoder().encode(encodable)
+      let json = String(data: data, encoding: encoding)
+      return json ?? "{}"
+    }
   }
 }

--- a/Sources/RxCodable/Single+RxCodable.swift
+++ b/Sources/RxCodable/Single+RxCodable.swift
@@ -26,23 +26,40 @@ public extension PrimitiveSequenceType where TraitType == SingleTrait, ElementTy
   }
 }
 
+public extension PrimitiveSequenceType where TraitType == SingleTrait, ElementType == [[String: Any]] {
+  public func map<T>(_ type: Array<T>.Type, using decoder: JSONDecoder? = nil) -> PrimitiveSequence<TraitType, [T]> where T: Decodable {
+    return self
+      .flatMap {
+        Observable.from($0)
+          .map(T.self, using: decoder)
+          .toArray()
+          .asSingle()
+      }
+  }
+}
+
 public extension PrimitiveSequenceType where TraitType == SingleTrait, ElementType: Encodable {
-  public func toDictionary(_ encoder: JSONEncoder? = nil) -> PrimitiveSequence<TraitType, [String: Any]> {
+  public func mapDictionary(_ encoder: JSONEncoder? = nil) -> PrimitiveSequence<TraitType, [String: Any]> {
     return self.map { encodable -> [String: Any] in
       let data = try (encoder ?? JSONEncoder()).encode(encodable)
       let dict = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-      guard let dictionary = dict else { throw RxError.noElements }
+      guard let dictionary = dict else {
+        throw RxCodableError.castingFailed(data: data, type: [String: Any].self)
+      }
       return dictionary
     }
   }
 }
 
 public extension PrimitiveSequenceType where TraitType == SingleTrait, ElementType: Encodable {
-  public func toJSONString(_ encoder: JSONEncoder? = nil, encoding: String.Encoding = .utf8) -> PrimitiveSequence<TraitType, String> {
+  public func mapJSONString(_ encoder: JSONEncoder? = nil, encoding: String.Encoding = .utf8) -> PrimitiveSequence<TraitType, String> {
     return self.map { encodable -> String in
       let data = try (encoder ?? JSONEncoder()).encode(encodable)
       let json = String(data: data, encoding: encoding)
-      return json ?? "{}"
+      guard let jsonString = json else {
+        throw RxCodableError.castingFailed(data: data, type: String.self)
+      }
+      return jsonString
     }
   }
 }

--- a/Tests/RxCodableTests/RxCodableTests.swift
+++ b/Tests/RxCodableTests/RxCodableTests.swift
@@ -79,12 +79,55 @@ class RxCodableTests: XCTestCase {
   
   func testMapCodableFromDictionary() {
     let dictionary:[String:Any] = [
-      "id":123,
-      "name":"iamchiwon",
+      "id": 123,
+      "name": "iamchiwon",
     ]
     let user = User(id: 123, name: "iamchiwon")
     XCTAssertEqual(try Observable.just(dictionary).map(User.self).toBlocking().first()!, user)
     XCTAssertEqual(try Single.just(dictionary).map(User.self).toBlocking().first()!, user)
     XCTAssertEqual(try Maybe.just(dictionary).map(User.self).toBlocking().first()!, user)
+  }
+  
+  func testMapCodableToDictionary() {
+    let dictionary:[String:Any] = [
+      "id": 123,
+      "name": "iamchiwon",
+      ]
+    let user = User(id: 123, name: "iamchiwon")
+    XCTAssertEqual(try Observable.just(user).toDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
+    XCTAssertEqual(try Single.just(user).toDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
+    XCTAssertEqual(try Maybe.just(user).toDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
+  }
+  
+  func testMapCodableToJSONString() {
+    let jsonString = """
+    {
+      "id": 123,
+      "name": "iamchiwon"
+    }
+    """
+    let user = User(id: 123, name: "iamchiwon")
+    XCTAssertEqual(try Observable.just(user).toJSONString().toBlocking().first()!,
+                   try Observable.just(jsonString).map(User.self).toJSONString().toBlocking().first()!)
+    XCTAssertEqual(try Single.just(user).toJSONString().toBlocking().first()!,
+                   try Single.just(jsonString).map(User.self).toJSONString().toBlocking().first()!)
+    XCTAssertEqual(try Maybe.just(user).toJSONString().toBlocking().first()!,
+                   try Maybe.just(jsonString).map(User.self).toJSONString().toBlocking().first()!)
+  }
+  
+  func testMapCodableFromJSONStringToDictionary() {
+    let jsonString = """
+    {
+      "id": 123,
+      "name": "iamchiwon"
+    }
+    """
+    let dictionary:[String:Any] = [
+      "id": 123,
+      "name": "iamchiwon",
+      ]
+    XCTAssertEqual(try Observable.just(jsonString).map(User.self).toDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
+    XCTAssertEqual(try Single.just(jsonString).map(User.self).toDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
+    XCTAssertEqual(try Maybe.just(jsonString).map(User.self).toDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
   }
 }

--- a/Tests/RxCodableTests/RxCodableTests.swift
+++ b/Tests/RxCodableTests/RxCodableTests.swift
@@ -92,7 +92,7 @@ class RxCodableTests: XCTestCase {
     let dictionary:[String:Any] = [
       "id": 123,
       "name": "iamchiwon",
-      ]
+    ]
     let user = User(id: 123, name: "iamchiwon")
     XCTAssertEqual(try Observable.just(user).toDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
     XCTAssertEqual(try Single.just(user).toDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
@@ -115,6 +115,31 @@ class RxCodableTests: XCTestCase {
                    try Maybe.just(jsonString).map(User.self).toJSONString().toBlocking().first()!)
   }
   
+  func testMapCodableArrayToJSONString() {
+    let jsonString = """
+    [
+      {
+        "id": 123,
+        "name": "iamchiwon"
+      },
+      {
+        "id": 456,
+        "name": "devxoul"
+      }
+    ]
+    """
+    let users = [
+      User(id: 123, name: "iamchiwon"),
+      User(id: 456, name: "devxoul"),
+    ]
+    XCTAssertEqual(try Observable.just(users).toJSONString().toBlocking().first()!,
+                   try Observable.just(jsonString).map([User].self).toJSONString().toBlocking().first()!)
+    XCTAssertEqual(try Single.just(users).toJSONString().toBlocking().first()!,
+                   try Single.just(jsonString).map([User].self).toJSONString().toBlocking().first()!)
+    XCTAssertEqual(try Maybe.just(users).toJSONString().toBlocking().first()!,
+                   try Maybe.just(jsonString).map([User].self).toJSONString().toBlocking().first()!)
+  }
+  
   func testMapCodableFromJSONStringToDictionary() {
     let jsonString = """
     {
@@ -125,7 +150,7 @@ class RxCodableTests: XCTestCase {
     let dictionary:[String:Any] = [
       "id": 123,
       "name": "iamchiwon",
-      ]
+    ]
     XCTAssertEqual(try Observable.just(jsonString).map(User.self).toDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
     XCTAssertEqual(try Single.just(jsonString).map(User.self).toDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
     XCTAssertEqual(try Maybe.just(jsonString).map(User.self).toDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)

--- a/Tests/RxCodableTests/RxCodableTests.swift
+++ b/Tests/RxCodableTests/RxCodableTests.swift
@@ -76,4 +76,15 @@ class RxCodableTests: XCTestCase {
     XCTAssertEqual(try Single.just(jsonString).map([User].self).toBlocking().first()!, users)
     XCTAssertEqual(try Maybe.just(jsonString).map([User].self).toBlocking().first()!, users)
   }
+  
+  func testMapCodableFromDictionary() {
+    let dictionary:[String:Any] = [
+      "id":123,
+      "name":"iamchiwon",
+    ]
+    let user = User(id: 123, name: "iamchiwon")
+    XCTAssertEqual(try Observable.just(dictionary).map(User.self).toBlocking().first()!, user)
+    XCTAssertEqual(try Single.just(dictionary).map(User.self).toBlocking().first()!, user)
+    XCTAssertEqual(try Maybe.just(dictionary).map(User.self).toBlocking().first()!, user)
+  }
 }

--- a/Tests/RxCodableTests/RxCodableTests.swift
+++ b/Tests/RxCodableTests/RxCodableTests.swift
@@ -78,7 +78,7 @@ class RxCodableTests: XCTestCase {
   }
   
   func testMapCodableFromDictionary() {
-    let dictionary:[String:Any] = [
+    let dictionary: [String:Any] = [
       "id": 123,
       "name": "iamchiwon",
     ]
@@ -88,18 +88,18 @@ class RxCodableTests: XCTestCase {
     XCTAssertEqual(try Maybe.just(dictionary).map(User.self).toBlocking().first()!, user)
   }
   
-  func testMapCodableToDictionary() {
-    let dictionary:[String:Any] = [
+  func testMapCodablemapDictionary() {
+    let dictionary: [String:Any] = [
       "id": 123,
       "name": "iamchiwon",
     ]
     let user = User(id: 123, name: "iamchiwon")
-    XCTAssertEqual(try Observable.just(user).toDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
-    XCTAssertEqual(try Single.just(user).toDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
-    XCTAssertEqual(try Maybe.just(user).toDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
+    XCTAssertEqual(try Observable.just(user).mapDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
+    XCTAssertEqual(try Single.just(user).mapDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
+    XCTAssertEqual(try Maybe.just(user).mapDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
   }
   
-  func testMapCodableToJSONString() {
+  func testMapCodablemapJSONString() {
     let jsonString = """
     {
       "id": 123,
@@ -107,15 +107,15 @@ class RxCodableTests: XCTestCase {
     }
     """
     let user = User(id: 123, name: "iamchiwon")
-    XCTAssertEqual(try Observable.just(user).toJSONString().toBlocking().first()!,
-                   try Observable.just(jsonString).map(User.self).toJSONString().toBlocking().first()!)
-    XCTAssertEqual(try Single.just(user).toJSONString().toBlocking().first()!,
-                   try Single.just(jsonString).map(User.self).toJSONString().toBlocking().first()!)
-    XCTAssertEqual(try Maybe.just(user).toJSONString().toBlocking().first()!,
-                   try Maybe.just(jsonString).map(User.self).toJSONString().toBlocking().first()!)
+    XCTAssertEqual(try Observable.just(user).mapJSONString().toBlocking().first()!,
+                   try Observable.just(jsonString).map(User.self).mapJSONString().toBlocking().first()!)
+    XCTAssertEqual(try Single.just(user).mapJSONString().toBlocking().first()!,
+                   try Single.just(jsonString).map(User.self).mapJSONString().toBlocking().first()!)
+    XCTAssertEqual(try Maybe.just(user).mapJSONString().toBlocking().first()!,
+                   try Maybe.just(jsonString).map(User.self).mapJSONString().toBlocking().first()!)
   }
   
-  func testMapCodableArrayToJSONString() {
+  func testMapCodableArraymapJSONString() {
     let jsonString = """
     [
       {
@@ -132,27 +132,50 @@ class RxCodableTests: XCTestCase {
       User(id: 123, name: "iamchiwon"),
       User(id: 456, name: "devxoul"),
     ]
-    XCTAssertEqual(try Observable.just(users).toJSONString().toBlocking().first()!,
-                   try Observable.just(jsonString).map([User].self).toJSONString().toBlocking().first()!)
-    XCTAssertEqual(try Single.just(users).toJSONString().toBlocking().first()!,
-                   try Single.just(jsonString).map([User].self).toJSONString().toBlocking().first()!)
-    XCTAssertEqual(try Maybe.just(users).toJSONString().toBlocking().first()!,
-                   try Maybe.just(jsonString).map([User].self).toJSONString().toBlocking().first()!)
+    XCTAssertEqual(try Observable.just(users).mapJSONString().toBlocking().first()!,
+                   try Observable.just(jsonString).map([User].self).mapJSONString().toBlocking().first()!)
+    XCTAssertEqual(try Single.just(users).mapJSONString().toBlocking().first()!,
+                   try Single.just(jsonString).map([User].self).mapJSONString().toBlocking().first()!)
+    XCTAssertEqual(try Maybe.just(users).mapJSONString().toBlocking().first()!,
+                   try Maybe.just(jsonString).map([User].self).mapJSONString().toBlocking().first()!)
   }
   
-  func testMapCodableFromJSONStringToDictionary() {
+  func testMapCodableFromJSONStringmapDictionary() {
     let jsonString = """
     {
       "id": 123,
       "name": "iamchiwon"
     }
     """
-    let dictionary:[String:Any] = [
+    let dictionary: [String:Any] = [
       "id": 123,
       "name": "iamchiwon",
     ]
-    XCTAssertEqual(try Observable.just(jsonString).map(User.self).toDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
-    XCTAssertEqual(try Single.just(jsonString).map(User.self).toDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
-    XCTAssertEqual(try Maybe.just(jsonString).map(User.self).toDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
+    XCTAssertEqual(try Observable.just(jsonString).map(User.self).mapDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
+    XCTAssertEqual(try Single.just(jsonString).map(User.self).mapDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
+    XCTAssertEqual(try Maybe.just(jsonString).map(User.self).mapDictionary().toBlocking().first()! as NSObject, dictionary as NSObject)
+  }
+  
+  func testMapCodableArraymapDictionary() {
+    let dictionaries: [[String:Any]] = [
+      [
+      "id": 123,
+      "name": "iamchiwon",
+      ],
+      [
+      "id": 456,
+      "name": "devxoul",
+      ]
+    ]
+    let users = [
+      User(id: 123, name: "iamchiwon"),
+      User(id: 456, name: "devxoul"),
+    ]
+    XCTAssertEqual(try Observable.just(dictionaries).map([User].self).mapJSONString().toBlocking().first()!,
+                   try Observable.just(users).mapJSONString().toBlocking().first()!)
+    XCTAssertEqual(try Single.just(dictionaries).map([User].self).mapJSONString().toBlocking().first()!,
+                   try Single.just(users).mapJSONString().toBlocking().first()!)
+    XCTAssertEqual(try Maybe.just(dictionaries).map([User].self).mapJSONString().toBlocking().first()!,
+                   try Maybe.just(users).mapJSONString().toBlocking().first()!)
   }
 }


### PR DESCRIPTION
My project using Firebase, needs convertings between Model and Dictionary, [String:Any].
So I added "toDictionary()"
and "toJSONString()" for POST request

1. when error occured, toDictionay() and toJSONString() returns empty not nil , followed your map() that returns empty Data when error
2. respected your coding convention, 2 space indent, and space after colon